### PR TITLE
Add Material UI login and signup pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# portalone
+# PortalOne
+
+This project provides a minimal Next.js setup featuring Material UI-based login and sign up pages.
+
+## Getting Started
+
+Install dependencies:
+
+```
+npm install
+```
+
+Run the development server:
+
+```
+npm run dev
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "portalone",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@mui/material": "5.15.11",
+    "@mui/icons-material": "5.15.11",
+    "@emotion/react": "11.11.1",
+    "@emotion/styled": "11.11.0"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import Head from 'next/head';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+
+const theme = createTheme();
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <React.Fragment>
+      <Head>
+        <title>PortalOne</title>
+        <meta name="viewport" content="initial-scale=1, width=device-width" />
+      </Head>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </React.Fragment>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,13 @@
+import { Container, Typography, Link } from '@mui/material';
+import NextLink from 'next/link';
+
+export default function Home() {
+  return (
+    <Container sx={{ mt: 8 }}>
+      <Typography variant="h4" gutterBottom>Welcome to PortalOne</Typography>
+      <Link component={NextLink} href="/login" underline="hover">
+        Go to Login
+      </Link>
+    </Container>
+  );
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,22 @@
+import { Container, TextField, Button, Box, Typography, Link } from '@mui/material';
+import NextLink from 'next/link';
+
+export default function Login() {
+  return (
+    <Container maxWidth="xs">
+      <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <Typography component="h1" variant="h5">Sign in</Typography>
+        <Box component="form" noValidate sx={{ mt: 1 }}>
+          <TextField margin="normal" required fullWidth label="Email Address" name="email" autoComplete="email" autoFocus />
+          <TextField margin="normal" required fullWidth name="password" label="Password" type="password" autoComplete="current-password" />
+          <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
+            Sign In
+          </Button>
+          <Link component={NextLink} href="/signup" variant="body2">
+            {"Don't have an account? Sign Up"}
+          </Link>
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,0 +1,23 @@
+import { Container, TextField, Button, Box, Typography, Link } from '@mui/material';
+import NextLink from 'next/link';
+
+export default function SignUp() {
+  return (
+    <Container maxWidth="xs">
+      <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <Typography component="h1" variant="h5">Sign up</Typography>
+        <Box component="form" noValidate sx={{ mt: 1 }}>
+          <TextField margin="normal" required fullWidth label="Name" name="name" autoFocus />
+          <TextField margin="normal" required fullWidth label="Email Address" name="email" autoComplete="email" />
+          <TextField margin="normal" required fullWidth name="password" label="Password" type="password" autoComplete="new-password" />
+          <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
+            Sign Up
+          </Button>
+          <Link component={NextLink} href="/login" variant="body2">
+            {"Already have an account? Sign In"}
+          </Link>
+        </Box>
+      </Box>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- set up Next.js project with Material UI
- add login and sign up pages with Material design
- document setup instructions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb8fb6bc948332b275f968c028821d