### PR TITLE
Add Google sign-in option

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -1,4 +1,5 @@
 import { Container, TextField, Button, Box, Typography, Link } from '@mui/material';
+import GoogleIcon from '@mui/icons-material/Google';
 import NextLink from 'next/link';
 
 export default function Login() {
@@ -11,6 +12,9 @@ export default function Login() {
           <TextField margin="normal" required fullWidth name="password" label="Password" type="password" autoComplete="current-password" />
           <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
             Sign In
+          </Button>
+          <Button fullWidth variant="contained" color="primary" startIcon={<GoogleIcon />} sx={{ mb: 2 }}>
+            Continue with Google
           </Button>
           <Link component={NextLink} href="/signup" variant="body2">
             {"Don't have an account? Sign Up"}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,4 +1,5 @@
 import { Container, TextField, Button, Box, Typography, Link } from '@mui/material';
+import GoogleIcon from '@mui/icons-material/Google';
 import NextLink from 'next/link';
 
 export default function SignUp() {
@@ -12,6 +13,9 @@ export default function SignUp() {
           <TextField margin="normal" required fullWidth name="password" label="Password" type="password" autoComplete="new-password" />
           <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
             Sign Up
+          </Button>
+          <Button fullWidth variant="contained" color="primary" startIcon={<GoogleIcon />} sx={{ mb: 2 }}>
+            Continue with Google
           </Button>
           <Link component={NextLink} href="/login" variant="body2">
             {"Already have an account? Sign In"}


### PR DESCRIPTION
## Summary
- add Google sign-in buttons to login and signup pages with a blue contained style

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb949aff2483329d4a2df663bbae6b