### PR TITLE
Add authenticated notes page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Run the development server:
 npm run dev
 ```
 
+Once signed in you can manage personal notes at `/notes`. Only authenticated users are able to create and view their notes, which are stored using Supabase.
+
 ## Environment Variables
 
 Create a `.env.local` file in the project root with the following values:

--- a/pages/notes.js
+++ b/pages/notes.js
@@ -1,0 +1,103 @@
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import {
+  Container,
+  TextField,
+  Button,
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText
+} from '@mui/material';
+import supabase from '../lib/supabaseClient';
+
+export default function Notes() {
+  const router = useRouter();
+  const [session, setSession] = useState(null);
+  const [notes, setNotes] = useState([]);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    const init = async () => {
+      const {
+        data: { session }
+      } = await supabase.auth.getSession();
+      if (!session) {
+        router.push('/login');
+        return;
+      }
+      setSession(session);
+      fetchNotes(session.user.id);
+    };
+    init();
+  }, [router]);
+
+  const fetchNotes = async (userId) => {
+    const { data, error } = await supabase
+      .from('notes')
+      .select('*')
+      .eq('user_id', userId)
+      .order('id', { ascending: false });
+    if (!error) {
+      setNotes(data);
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!session) return;
+    const { error } = await supabase.from('notes').insert({
+      user_id: session.user.id,
+      title,
+      content
+    });
+    if (!error) {
+      setTitle('');
+      setContent('');
+      fetchNotes(session.user.id);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box sx={{ mt: 8 }}>
+        <Typography component="h1" variant="h4" gutterBottom>
+          My Notes
+        </Typography>
+        <Box component="form" onSubmit={handleSubmit} sx={{ mb: 4 }}>
+          <TextField
+            label="Title"
+            fullWidth
+            margin="normal"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+          <TextField
+            label="Content"
+            fullWidth
+            margin="normal"
+            multiline
+            rows={4}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            required
+          />
+          <Button type="submit" variant="contained">
+            Add Note
+          </Button>
+        </Box>
+        <List>
+          {notes.map((note) => (
+            <ListItem key={note.id} alignItems="flex-start">
+              <ListItemText primary={note.title} secondary={note.content} />
+            </ListItem>
+          ))}
+        </List>
+      </Box>
+    </Container>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `/notes` page to create and list notes for the signed-in user using Supabase
- document notes feature in README

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68be8484eb608332ad3ace12c267c5fd