### PR TITLE
Redirect to notes page after sign in

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -20,12 +20,16 @@ export default function Login() {
       console.error(error.message);
     } else {
       setErrorMessage('');
-      router.push('/dashboard');
+      router.push('/notes');
     }
   };
 
   const handleGoogle = async () => {
-    const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
+    const origin = process.env.NEXT_PUBLIC_SITE_URL || window.location.origin;
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: `${origin}/notes` }
+    });
     if (error) console.error(error.message);
   };
 


### PR DESCRIPTION
## Summary
- Redirect sign-in flow to the Notes page
- Send Google OAuth users to Notes after authentication

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68be87fc69b88332ab1711dd621e9b41