### PR TITLE
Display notes in grid and handle save errors

### DIFF
--- a/pages/notes.js
+++ b/pages/notes.js
@@ -6,9 +6,9 @@ import {
   Button,
   Box,
   Typography,
-  List,
-  ListItem,
-  ListItemText
+  Grid,
+  Card,
+  CardContent
 } from '@mui/material';
 import supabase from '../lib/supabaseClient';
 
@@ -49,20 +49,27 @@ export default function Notes() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!session) return;
-    const { error } = await supabase.from('notes').insert({
-      user_id: session.user.id,
-      title,
-      content
-    });
-    if (!error) {
+    const { data, error } = await supabase
+      .from('notes')
+      .insert({
+        user_id: session.user.id,
+        title,
+        content
+      })
+      .select();
+    if (error) {
+      alert(`Error saving note: ${error.message}`);
+      return;
+    }
+    if (data) {
+      setNotes((prev) => [...data, ...prev]);
       setTitle('');
       setContent('');
-      fetchNotes();
     }
   };
 
   return (
-    <Container maxWidth="sm">
+    <Container maxWidth="md">
       <Box sx={{ mt: 8 }}>
         <Typography component="h1" variant="h4" gutterBottom>
           My Notes
@@ -90,13 +97,20 @@ export default function Notes() {
             Add Note
           </Button>
         </Box>
-        <List>
+        <Grid container spacing={2}>
           {notes.map((note) => (
-            <ListItem key={note.id} alignItems="flex-start">
-              <ListItemText primary={note.title} secondary={note.content} />
-            </ListItem>
+            <Grid item xs={12} sm={6} md={4} key={note.id}>
+              <Card>
+                <CardContent>
+                  <Typography variant="h6" gutterBottom>
+                    {note.title}
+                  </Typography>
+                  <Typography variant="body2">{note.content}</Typography>
+                </CardContent>
+              </Card>
+            </Grid>
           ))}
-        </List>
+        </Grid>
       </Box>
     </Container>
   );


### PR DESCRIPTION
## Summary
- show personal notes in a responsive MUI card grid
- render newly created notes immediately after saving and alert on save errors

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68be902b1a2c8332a8e366f77f2ac660