### PR TITLE
Display note creation dates

### DIFF
--- a/pages/notes.js
+++ b/pages/notes.js
@@ -52,7 +52,7 @@ export default function Notes() {
       .from('notes')
       .select('*')
       .eq('user_id', currentSession.user.id)
-      .order('id', { ascending: false });
+      .order('created_at', { ascending: false });
     if (!error) {
       setNotes(data);
     }
@@ -125,6 +125,14 @@ export default function Notes() {
                     {note.title}
                   </Typography>
                   <Typography variant="body2">{note.content}</Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    display="block"
+                    sx={{ mt: 1 }}
+                  >
+                    {new Date(note.created_at).toLocaleString()}
+                  </Typography>
                 </CardContent>
               </Card>
             </Grid>


### PR DESCRIPTION
## Summary
- Order notes by the existing `created_at` timestamp
- Insert new notes without adding a custom timestamp
- Show each note's `created_at` date in the list

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68be9a5378308332920d14e781d27069